### PR TITLE
Migrate to vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "next lint",
     "bot:build": "tsc ./src/bot/index.ts --noEmit false --esModuleInterop --outDir ./build",
     "bot:start": "probot run ./build/index.js",
-    "test": "jest"
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "next": "^13.4.19",
@@ -22,16 +22,18 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.4",
     "@types/node": "^20.6.0",
     "@types/react": "^18.2.21",
+    "@vitejs/plugin-react": "^4.0.4",
+    "@vitest/coverage-v8": "^0.34.4",
     "eslint": "8.49.0",
     "eslint-config-next": "13.4.19",
-    "jest": "^29.7.0",
+    "jsdom": "^22.1.0",
     "nock": "^13.3.3",
     "smee-client": "^1.2.3",
-    "ts-jest": "^29.1.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "vite-tsconfig-paths": "^4.2.1",
+    "vitest": "^0.34.4"
   },
   "engines": {
     "node": ">= 14"

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,4 +1,5 @@
 import nock from "nock";
+import { afterEach, beforeEach, describe, test } from "vitest";
 
 // Requiring our app implementation
 import app from "@/bot";
@@ -33,7 +34,7 @@ describe("My Probot app", () => {
     probot.load(app);
   });
 
-  test("creates a comment when an issue is opened", async (done) => {
+  test("creates a comment when an issue is opened", async ({ expect }) => {
     const mock = nock("https://api.github.com")
       // Test that we correctly return a test token
       .post("/app/installations/2/access_tokens")
@@ -46,7 +47,7 @@ describe("My Probot app", () => {
 
       // Test that a comment is posted
       .post("/repos/hiimbex/testing-things/issues/1/comments", (body: any) => {
-        done(expect(body).toMatchObject(issueCreatedBody));
+        expect(body).toMatchObject(issueCreatedBody);
         return true;
       })
       .reply(200);
@@ -62,12 +63,6 @@ describe("My Probot app", () => {
     nock.enableNetConnect();
   });
 });
-
-// For more information about testing with Jest see:
-// https://facebook.github.io/jest/
-
-// For more information about using TypeScript in your tests, Jest recommends:
-// https://github.com/kulshekhar/ts-jest
 
 // For more information about testing with Nock see:
 // https://github.com/nock/nock

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
+// import magicalSvg from "vite-plugin-magical-svg";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react(), tsconfigPaths() /*, magicalSvg({ target: "react" })*/],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    // setupFiles: ["dotenv/config", "src/testUtils/vitestSetup.ts"],
+    coverage: {
+      reporter: ["text", "json", "html"],
+    },
+    threads: true,
+  },
+});


### PR DESCRIPTION
Why?
- jest had TypeScript issues
- vitest is modern and fast alternative to jest